### PR TITLE
Add maven building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.jar
 build/
 out/
+target/

--- a/how-to-build.md
+++ b/how-to-build.md
@@ -1,0 +1,7 @@
+LightSheetManager can be built with maven
+
+To do so, `MMJ_.jar`, which contains the code for the Micro-Manager java layer, must be copied into `LightSheetManager/lib/MMJ_.jar`
+
+To build, run `mvn clean package` from the `LightSheetManager`. The resultant jar will be available in the `LightSheetManager/target` folder, and then must be manually copied into the `Micro-manager/mmplugins`. 
+
+Doing this requires having Maven installed. Most IDEs have a Maven plugin that can accomplish the same thing as the manual way above.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,207 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.micro-manager.lightsheetmanager</groupId>
+    <artifactId>LightSheetManager</artifactId>
+    <version>0.1.0</version>
+    <packaging>jar</packaging>
+    <name>LightSheetManager plugin</name>
+    <description>Java-based Micro-Manager plugin for controlling light sheet microscopes</description>
+    <url>https://github.com/micro-manager/LightSheetManager</url>
+
+  
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <developers>
+       <developer>
+          <id>bls337</id>
+          <name>Brandon Simpson</name>
+          <organization>ASI</organization>
+       </developer>
+       <developer>
+          <id>jondaniels</id>
+          <name>Jon Daniels</name>
+          <organization>ASI</organization>
+       </developer>
+       <developer>
+          <id>nicost</id>
+          <name>Nico Stuurman</name>
+          <organization>Altos Labs</organization>
+       </developer>
+    </developers>
+
+   <scm>
+      <url>https://github.com/micro-manager/LightSheetManager</url>
+    <connection>scm:git:git://github.com/micro-manager/LightSheetManager.git</connection>
+    <developerConnection>scm:git:git@github.com:micro-manager/LightSheetManager.git</developerConnection>
+   </scm>
+
+   
+   <licenses>
+      <license>
+         <name>BSD-3</name>
+         <url>https://github.com/micro-manager/LightSheetManager/blob/master/LICENSE</url>
+       </license>
+   </licenses>
+
+
+	<dependencies>
+		<dependency>
+			<groupId>org.micro-manager.mmcorej</groupId>
+			<artifactId>MMCoreJ</artifactId>
+			<version>10.1.1.0</version>
+		</dependency>
+
+      <!-- TODO: switch to a remote repo for MMJ once it is mavenized -->
+<!--       <dependency>
+         <groupId>org.micro-manager</groupId>
+         <artifactId>MMJ_</artifactId>
+         <version>10.1.1.0</version>
+      </dependency> -->
+
+   <dependency>
+       <groupId>com.sample</groupId>
+       <artifactId>sample</artifactId>
+       <version>1.0</version>
+       <scope>system</scope>
+       <systemPath>${project.basedir}/lib/MMJ_.jar</systemPath>
+   </dependency>
+
+
+   <dependency>
+       <groupId>com.miglayout</groupId>
+       <artifactId>miglayout-swing</artifactId>
+       <version>4.2</version>
+   </dependency>
+
+<dependency>
+    <groupId>com.google.code.gson</groupId>
+    <artifactId>gson</artifactId>
+    <version>2.2.4</version>
+</dependency>
+
+<dependency>
+    <groupId>org.scijava</groupId>
+    <artifactId>scijava-common</artifactId>
+    <version>2.77.0</version>
+</dependency>
+
+<dependency>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava</artifactId>
+    <version>17.0</version>
+</dependency>
+
+<dependency>
+    <groupId>commons-io</groupId>
+    <artifactId>commons-io</artifactId>
+    <version>2.11.0</version>
+</dependency>
+
+<dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-math3</artifactId>
+    <version>3.6.1</version>
+</dependency>
+
+<dependency>
+    <groupId>com.sun.activation</groupId>
+    <artifactId>javax.activation</artifactId>
+    <version>1.2.0</version>
+</dependency>
+
+<dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.12</version>
+    <scope>test</scope>
+</dependency>
+
+	</dependencies>
+
+
+    <build>
+
+      <plugins>
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+         <execution>
+          <id>attach-sources</id>
+          <goals>
+           <goal>jar-no-fork</goal>
+          </goals>
+         </execution>
+        </executions>
+       </plugin>
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+         <execution>
+          <id>attach-javadocs</id>
+          <goals>
+           <goal>jar</goal>
+          </goals>
+         </execution>
+        </executions>
+       </plugin>
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+         <execution>
+          <id>sign-artifacts</id>
+          <phase>verify</phase>
+          <goals>
+           <goal>sign</goal>
+          </goals>
+		 
+		<configuration>
+             	<gpgArguments>
+			<arg>--pinentry-mode</arg>
+			<arg>loopback</arg>
+		</gpgArguments>
+	     </configuration>
+		 
+		 
+         </execution>
+        </executions>
+       </plugin>
+       <plugin>
+      <groupId>org.sonatype.plugins</groupId>
+      <artifactId>nexus-staging-maven-plugin</artifactId>
+      <version>1.6.7</version>
+      <extensions>true</extensions>
+      <configuration>
+         <serverId>ossrh</serverId>
+         <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+         <autoReleaseAfterClose>true</autoReleaseAfterClose>
+      </configuration>
+    </plugin>
+      </plugins>
+     </build>
+
+
+
+    <distributionManagement>
+      <snapshotRepository>
+        <id>ossrh</id>
+        <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      </snapshotRepository>
+      <repository>
+        <id>ossrh</id>
+        <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      </repository>
+   </distributionManagement>
+
+
+</project>

--- a/src/main/java/org/micromanager/lightsheetmanager/model/utils/MyNumberUtils.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/utils/MyNumberUtils.java
@@ -49,7 +49,7 @@ public class MyNumberUtils {
    
    /**
     * 
-    * @param f
+    * @param d
     * @param place number of places after decimal point, between 0 and 9
     * @return
     */

--- a/src/main/java/org/micromanager/lightsheetmanager/model/utils/jplus/PredicateUtils.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/utils/jplus/PredicateUtils.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
- * JDK11 added a static Predicate.not() method to the Predicate<T> interface.
+ * JDK11 added a static Predicate.not() method to the Predicate interface.
  * This can be removed and replaced if Micro-Manager adopts JDK11.
  */
 public interface PredicateUtils {

--- a/src/test/java/org/micromanager/lightsheetmanager/internal/AutofocusSettingsTest.java
+++ b/src/test/java/org/micromanager/lightsheetmanager/internal/AutofocusSettingsTest.java
@@ -4,8 +4,9 @@ package org.micromanager.lightsheetmanager.internal;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.micromanager.lightsheetmanager.AutofocusSettings;
-import org.micromanager.lightsheetmanager.LightSheetManager;
+import org.micromanager.lightsheetmanager.api.AutofocusSettings;
+import org.micromanager.lightsheetmanager.api.LightSheetManager;
+import org.micromanager.lightsheetmanager.api.internal.DefaultLightSheetManager;
 
 public class AutofocusSettingsTest {
    private final int numImages_ = 14;

--- a/src/test/java/org/micromanager/lightsheetmanager/internal/TimingSettingsTest.java
+++ b/src/test/java/org/micromanager/lightsheetmanager/internal/TimingSettingsTest.java
@@ -3,8 +3,9 @@ package org.micromanager.lightsheetmanager.internal;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.micromanager.lightsheetmanager.LightSheetManager;
-import org.micromanager.lightsheetmanager.TimingSettings;
+import org.micromanager.lightsheetmanager.api.LightSheetManager;
+import org.micromanager.lightsheetmanager.api.TimingSettings;
+import org.micromanager.lightsheetmanager.api.internal.DefaultLightSheetManager;
 
 public class TimingSettingsTest {
     private final boolean useAdvancedTiming_ = true;

--- a/src/test/java/org/micromanager/lightsheetmanager/internal/VolumeSettingsTest.java
+++ b/src/test/java/org/micromanager/lightsheetmanager/internal/VolumeSettingsTest.java
@@ -4,11 +4,13 @@ package org.micromanager.lightsheetmanager.internal;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.micromanager.lightsheetmanager.VolumeSettings;
-import org.micromanager.lightsheetmanager.LightSheetManager;
+import org.micromanager.lightsheetmanager.api.LightSheetManager;
+import org.micromanager.lightsheetmanager.api.VolumeSettings;
+import org.micromanager.lightsheetmanager.api.internal.DefaultLightSheetManager;
 
 public class VolumeSettingsTest {
-    private final String firstView_ = "B";
+    //TODO: Is firstview supposed to be Stirng or int?
+    private final int firstView_ = 0;
     private final double viewDelayMs_ = 100;
     private final int numViews_ = 2;
 


### PR DESCRIPTION
This PR enables LightSheetManager to be automatically built with Maven. To use it, do the following:

Copy MMJ_.jar from `Micro-Manager/plugins/micro-manager`  to `LightSheetManager/lib/MMJ_.jar`

Install Maven

Run `mvn clean package` from the `LightSheetManager`. The resultant jar will be available in the `LightSheetManager/target` folder, and then must be manually copied into the `Micro-manager/mmplugins`. 

Doing this requires having Maven installed. Most IDEs have a Maven plugin that can accomplish the same thing as the manual way above.

This build mechanism will need to be updated as the build system for micro-manager gets restructured and improved (https://github.com/micro-manager/micro-manager/issues/1392)