### PR TITLE
PORT: fix display of durations on the acquisition panel

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -1364,6 +1364,8 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
         }
     }
 
+    // TODO: Inherited rounding quirk, not a regression: Math.round(duration % 60) can produce "1 min 60 s"
+    //   for e.g. duration = 119.7 s. diSPIM has the same behavior, so as a faithful port this is fine.
     /**
      * Update the displayed total time duration.
      */
@@ -1372,11 +1374,13 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
         if (duration < 60) {  // less than 1 min
             label.setText(NumberUtils.doubleToDisplayString(duration) + " s");
         } else if (duration < (60*60)) { // between 1 min and 1 hour
-            label.setText(NumberUtils.doubleToDisplayString(Math.floor(duration/60)) + " min");
-            label.setText(NumberUtils.doubleToDisplayString((double)Math.round(duration % 60)) + " s");
+            final String minutes = NumberUtils.doubleToDisplayString(Math.floor(duration/60)) + " min ";
+            final String seconds = NumberUtils.doubleToDisplayString((double)Math.round(duration % 60)) + " s";
+            label.setText(minutes + seconds);
         } else { // longer than 1 hour
-            label.setText(NumberUtils.doubleToDisplayString(Math.floor(duration/(60*60))) + " hr");
-            label.setText(NumberUtils.doubleToDisplayString((double)Math.round((duration % (60*60))/60)) + " min");
+            final String hours = NumberUtils.doubleToDisplayString(Math.floor(duration/(60*60))) + " hr ";
+            final String minutes = NumberUtils.doubleToDisplayString((double)Math.round((duration % (60*60))/60)) + " min";
+            label.setText(hours + minutes);
         }
     }
 

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -974,7 +974,8 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
             }
         }
 
-        if (acqSettings_.isUsingMultiplePositions() && acqSettings_.numTimePoints() > 1) {
+        final int numTimePoints = acqSettings_.isUsingTimePoints() ? acqSettings_.numTimePoints() : 1;
+        if (acqSettings_.isUsingMultiplePositions() && numTimePoints > 1) {
             if (timepointIntervalMs < volumeDuration) {
                 studio_.logs().showError("Time point interval shorter than the time to collect a single volume.");
                 return false;

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -1385,8 +1385,8 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
     }
 
     private double computeTotalTimeDuration() {
-        return (acqSettings_.numTimePoints() - 1) * acqSettings_.timePointInterval()
-                + computeTimePointDuration() / 1000.0;
+        final int numTimePoints = acqSettings_.isUsingTimePoints() ? acqSettings_.numTimePoints() : 1;
+        return (numTimePoints - 1) * acqSettings_.timePointInterval() + computeTimePointDuration() / 1000.0;
     }
 
     /**


### PR DESCRIPTION
1.
The 1.4 diSPIM plugin uses `getNumTimepoints()` which always returns 1  if time points are enabled, LSM was using `acqSettings_.numTimePoints()` directly, LSM now matches the behavior of the original plugin in `computeActualTimeLapseDuration()` => `computeTotalTimeDuration()`.

2.
There was also a GUI display bug in the port of the code where it would only write the seconds in the  `// between 1 min and 1 hour` branch and only write the minutes in the `// longer than 1 hour` branch. Very clear bug.

3.
There was another place in `AcquisitionEngineScape.java` that used `acqSettings_.numTimePoints()` directly when it needed to clamp the value to 1 if time points are not enabled.

The number of time points could be a left over value such as 10 and trigger this code even if not enabled.

TODO: it looks like I missed the `!` in the port for item 3, I will add this in one of the next commits.

```java
   // Item 1
   private int getNumTimepoints() {
      if (useTimepointsCB_.isSelected()) {
         return (Integer) numTimepoints_.getValue();
      } else {
         return 1;
      }
   }
   
   private double computeActualTimeLapseDuration() {
      double duration = (getNumTimepoints() - 1) * getTimepointInterval() 
            + computeTimepointDuration()/1000;
      return duration;
   }
   
    // Item 2
    private void updateActualTimeLapseDurationLabel() {
      String s = "";
      double duration = computeActualTimeLapseDuration();
      if (duration < 60) {  // less than 1 min
         s += NumberUtils.doubleToDisplayString(duration) + " s";
      } else if (duration < 60*60) { // between 1 min and 1 hour
         s += NumberUtils.doubleToDisplayString(Math.floor(duration/60)) + " min ";
         s += NumberUtils.doubleToDisplayString(Math.round(duration %  60)) + " s";
      } else { // longer than 1 hour
         s += NumberUtils.doubleToDisplayString(Math.floor(duration/(60*60))) + " hr ";
         s +=  NumberUtils.doubleToDisplayString(Math.round((duration % (60*60))/60)) + " min";
      }
      actualTimeLapseDurationLabel_.setText(s);
   }
   
      // Item 3   
      // make sure we aren't trying to collect timepoints faster than we can
      if (!acqSettings.useMultiPositions && acqSettings.numTimepoints > 1) {
         if (timepointIntervalMs < volumeDuration) {
            MyDialogUtils.showError("Time point interval shorter than" +
                  " the time to collect a single volume.", hideErrors);
            return AcquisitionStatus.FATAL_ERROR;
         }
      }
```