### PR TITLE
PORT: update behavior for duration labels from 1.4 diSPIM plugin

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/AcquisitionTab.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/AcquisitionTab.java
@@ -291,10 +291,10 @@ public class AcquisitionTab extends Panel implements ListeningPanel, SettingsLis
             swapTimingSettingsPanels(selected);
             if (selected) {
                 pnlAdvancedTiming_.updateSpinners();
-            } else {
-                model_.acquisitions().updateSettings();
-                model_.acquisitions().recalculateSliceTiming();
             }
+            // update slice timing and duration labels
+            model_.acquisitions().updateSettings();
+            model_.acquisitions().updateDurationLabels();
         });
     }
 

--- a/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/acquisition/CameraPanel.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/acquisition/CameraPanel.java
@@ -113,6 +113,9 @@ public class CameraPanel extends Panel implements SettingsListener {
         cmbCameraMode_.registerListener(() -> {
             final CameraMode cameraMode = cmbCameraMode_.getSelected();
             model_.acquisitions().settingsBuilder().cameraMode(cameraMode);
+            // update slice timing and duration labels
+            model_.acquisitions().updateSettings();
+            model_.acquisitions().updateDurationLabels();
         });
 
         // select primary camera

--- a/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/acquisition/SlicePanel.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/acquisition/SlicePanel.java
@@ -100,25 +100,25 @@ public class SlicePanel extends Panel implements SettingsListener {
             spnSlicePeriod_.setEnabled(!selected);
             model_.acquisitions().settingsBuilder()
                     .sliceBuilder().periodMinimized(selected);
-            // update slice timing
+            // update slice timing and duration labels
             model_.acquisitions().updateSettings();
-            model_.acquisitions().recalculateSliceTiming();
+            model_.acquisitions().updateDurationLabels();
         });
 
         spnSlicePeriod_.registerListener(() -> {
             model_.acquisitions().settingsBuilder()
                     .sliceBuilder().period(spnSlicePeriod_.getDouble());
-            // update slice timing
+            // update slice timing and duration labels
             model_.acquisitions().updateSettings();
-            model_.acquisitions().recalculateSliceTiming();
+            model_.acquisitions().updateDurationLabels();
         });
 
         spnSampleExposure_.registerListener(() -> {
             model_.acquisitions().settingsBuilder()
                     .sliceBuilder().sampleExposure(spnSampleExposure_.getDouble());
-            // update slice timing
+            // update slice timing and duration labels
             model_.acquisitions().updateSettings();
-            model_.acquisitions().recalculateSliceTiming();
+            model_.acquisitions().updateDurationLabels();
         });
 
 //        if (model_.devices().adapter().geometry() == GeometryType.DISPIM) {

--- a/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/acquisition/VolumePanel.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/acquisition/VolumePanel.java
@@ -116,11 +116,13 @@ public class VolumePanel extends Panel implements SettingsListener {
             cmbNumViews_.registerListener(() -> {
                 model_.acquisitions().settingsBuilder().volumeBuilder()
                         .numViews(cmbNumViews_.getSelected());
+                model_.acquisitions().updateDurationLabels();
             });
 
             cmbFirstView_.registerListener(() -> {
                 model_.acquisitions().settingsBuilder().volumeBuilder()
                         .firstView(cmbFirstView_.getSelected());
+                model_.acquisitions().updateDurationLabels();
             });
         }
 
@@ -139,6 +141,8 @@ public class VolumePanel extends Panel implements SettingsListener {
         spnSliceStepSize_.registerListener(() -> {
             model_.acquisitions().settingsBuilder().volumeBuilder()
                     .sliceStepSize(spnSliceStepSize_.getDouble());
+            // needed only for stage scanning b/c acceleration time related to speed
+            model_.acquisitions().updateDurationLabels();
         });
     }
 


### PR DESCRIPTION
1.
 Always update the duration labels when when checking/unchecking the Advanced Timing check box. LSM previously only updated the duration labels when the unchecked.

2.
`VolumePanel.java`  now updates the duration labels when `spnSliceStepSize_` , `cmbNumViews_`, and `cmbFirstView_` change. 

`cmbNumViews_` and `cmbFirstView_`  are not used in SCAPE, but will be useful when implementing diSPIM.

We pulled the comment directly from the original plugin for `spnSliceStepSize_`.

3.
`SlicePanel.java` now updates the duration labels when `spnSampleExposure_`, `spnSlicePeriod_`, and `cbxMinimizePeriod_` are changed.

4.
Note: this has no direct equivalent in the 1.4 plugin. This fixes a staleness bug in the duration labels.

`CameraPanel.java` now updates the duration labels when the camera trigger mode is changed.

```java
      // Item 1
      // this action listener takes care of enabling/disabling inputs
      // of the advanced slice timing window
      // we call this to get GUI looking right
      ItemListener sliceTimingDisableGUIInputs = new ItemListener() {
         @Override
         public void itemStateChanged(ItemEvent e) {
            boolean enabled = advancedSliceTimingCB_.isSelected();
            // set other components in this advanced timing frame
            PanelUtils.componentsSetEnabled(advancedTimingComponents, enabled);
            // also control some components in main volume settings sub-panel
            PanelUtils.componentsSetEnabled(simpleTimingComponents_, !enabled);
            desiredSlicePeriod_.setEnabled(!enabled && !minSlicePeriodCB_.isSelected());
            desiredSlicePeriodLabel_.setEnabled(!enabled && !minSlicePeriodCB_.isSelected());
            updateDurationLabels();
         } 
      };
      
// Item 2
firstSide_.addActionListener(recalculateTimingDisplayAL); // this is cmbFirstView_in LSM

numSides_.addActionListener(recalculateTimingDisplayAL); // this is cmbNumViews_ in LSM

pu.addListenerLast(stepSize_, recalculateTimingDisplayCL);  // needed only for stage scanning b/c acceleration time related to speed (spnSliceStepSize_ in LSM)

// Item 3

// indirectly updated in recalculateSliceTiming(), which calls setValue on delayLaser_ and other variables that have recalculateTimingDisplayCL attached to them.

minSlicePeriodCB_.addActionListener(new ActionListener() {
           @Override
           public void actionPerformed(ActionEvent e) {
              boolean doMin = minSlicePeriodCB_.isSelected();
              desiredSlicePeriod_.setEnabled(!doMin);
              desiredSlicePeriodLabel_.setEnabled(!doMin);
              recalculateSliceTiming(false);
           }
        });

desiredLightExposure_.addChangeListener(recalculateTimingDisplayCL); // this is spnSampleExposure_ in LSM

desiredSlicePeriod_.addChangeListener(recalculateTimingDisplayCL); // this is spnSlicePeriod_ in LSM

// Item 4

camModeCB_  // check the original 1.4 plugin for details


```