### PR TITLE
PORT: the MM 1.4 diSPIM plugin uses logical negation for this check

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -975,7 +975,7 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
         }
 
         final int numTimePoints = acqSettings_.isUsingTimePoints() ? acqSettings_.numTimePoints() : 1;
-        if (acqSettings_.isUsingMultiplePositions() && numTimePoints > 1) {
+        if (!acqSettings_.isUsingMultiplePositions() && numTimePoints > 1) {
             if (timepointIntervalMs < volumeDuration) {
                 studio_.logs().showError("Time point interval shorter than the time to collect a single volume.");
                 return false;


### PR DESCRIPTION
This is a fix for an issue identified in #421

We need to use `!acqSettings_.isUsingMultiplePositions() ` here to match the original plugin.

```
      // make sure we aren't trying to collect timepoints faster than we can
      if (!acqSettings.useMultiPositions && acqSettings.numTimepoints > 1) {
         if (timepointIntervalMs < volumeDuration) {
            MyDialogUtils.showError("Time point interval shorter than" +
                  " the time to collect a single volume.", hideErrors);
            return AcquisitionStatus.FATAL_ERROR;
         }
      }
```