### PR TITLE
prevent acquisition engine from getting stuck if finish() throws

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -146,6 +146,8 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                 } catch (Exception e) {
                     studio_.logs().showError(e, "Error during acquisition cleanup");
                 } finally {
+                    // must ALWAYS run: if currentAcquisition_ is left set, every future
+                    // acquisition is rejected until the plugin restarts
                     currentAcquisition_ = null;
                 }
             }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -141,8 +141,13 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
             } catch (Exception e) {
                 studio_.logs().showError(e);
             } finally {
-                finish(); // cleanup any resources
-                currentAcquisition_ = null;
+                try {
+                    finish(); // cleanup any resources
+                } catch (Exception e) {
+                    studio_.logs().showError(e, "Error during acquisition cleanup");
+                } finally {
+                    currentAcquisition_ = null;
+                }
             }
         });
         return acqFinished;


### PR DESCRIPTION
prevent acquisition engine from getting stuck if finish() throws

If cleanup failed, `currentAcquisition_` was never cleared and every
subsequent run was rejected with `"Acquisition is already running."`
Now the error is shown and the engine always recovers.