### PR TITLE
diSPIM: update the acq eng to match SCAPE's finish() method, fixes some bugs for both engines along the way

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -39,6 +39,7 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
     private boolean isPolling_; // true if polling was enabled at the start of an acquisition
 
     PLogicDispim controller_;
+    ArrayList<Double> savedExposures_;
     private boolean isShutterOpen_;
     private boolean autoShutter_;
 
@@ -76,6 +77,13 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
             if (studio_.live().getDisplay() != null) {
                 studio_.live().getDisplay().close();
             }
+        }
+
+        // save current exposure to restore later
+        final CameraBase[] cameras = model_.devices().imagingCameras();
+        savedExposures_ = new ArrayList<>();
+        for (CameraBase camera : cameras) {
+            savedExposures_.add(camera.getExposure());
         }
 
         final boolean isUsingPLC = model_.devices().isUsingPLogic();
@@ -524,6 +532,13 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
             } catch (Exception e) {
                 studio_.logs().logError(e);
             }
+        }
+
+        // set the camera trigger modes back to internal for live mode
+        for (int i = 0; i < cameras.length; i++) {
+            CameraBase camera = cameras[i];
+            camera.setTriggerMode(CameraMode.INTERNAL);
+            camera.setExposure(savedExposures_.get(i));
         }
 
         // unregister to stop ghost events

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -39,7 +39,7 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
     private boolean isPolling_; // true if polling was enabled at the start of an acquisition
 
     PLogicDispim controller_;
-    ArrayList<Double> savedExposures_;
+    ArrayList<Double> savedExposures_ = new ArrayList<>();
     private boolean isShutterOpen_;
     private boolean autoShutter_;
 
@@ -535,10 +535,12 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
         }
 
         // set the camera trigger modes back to internal for live mode
-        for (int i = 0; i < cameras.length; i++) {
-            CameraBase camera = cameras[i];
-            camera.setTriggerMode(CameraMode.INTERNAL);
-            camera.setExposure(savedExposures_.get(i));
+        if (savedExposures_.size() == cameras.length) {
+            for (int i = 0; i < cameras.length; i++) {
+                CameraBase camera = cameras[i];
+                camera.setTriggerMode(CameraMode.INTERNAL);
+                camera.setExposure(savedExposures_.get(i));
+            }
         }
 
         // unregister to stop ghost events

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -38,6 +38,9 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
     private boolean isPolling_; // true if polling was enabled at the start of an acquisition
 
+    private boolean isShutterOpen_;
+    private boolean autoShutter_;
+
 //    private DefaultAcquisitionSettingsDISPIM.Builder asb_;
    // TODO: remove this when a more generic method is available and get from base class
     private DispimAcquisitionSettings acqSettings_;
@@ -353,19 +356,18 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
 
         ///////////// Turn off autoshutter /////////////////
-        final boolean isShutterOpen;
         try {
-            isShutterOpen = core_.getShutterOpen();
+            isShutterOpen_ = core_.getShutterOpen();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
 
         // TODO: should the shutter be left open for the full duration of acquisition?
         //  because that's what this code currently does
-        boolean autoShutter = core_.getAutoShutter();
-        if (autoShutter) {
+        autoShutter_ = core_.getAutoShutter();
+        if (autoShutter_) {
             core_.setAutoShutter(false);
-            if (!isShutterOpen) {
+            if (!isShutterOpen_) {
                 try {
                     core_.setShutterOpen(true);
                 } catch (Exception e) {
@@ -484,21 +486,6 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
             controller.stopSPIMStateMachines();
         }
 
-        // Restore shutter/autoshutter to original state
-        try {
-            core_.setShutterOpen(isShutterOpen);
-            core_.setAutoShutter(autoShutter);
-        } catch (Exception e) {
-            throw new RuntimeException("Couldn't restore shutter to original state");
-        }
-
-        // Check if acquisition ended due to an exception and show error to user if it did
-        try {
-            currentAcquisition_.checkForExceptions();
-        } catch (Exception e) {
-            studio_.logs().showError(e);
-        }
-
         // TODO: execute any end-acquisition runnables
 
         return true;
@@ -518,6 +505,24 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
             }
         } catch (Exception e) {
             studio_.logs().logError("Could not stop camera sequences: " + e.getMessage());
+        }
+
+        // Restore shutter/autoshutter to original state
+        try {
+            core_.setShutterOpen(isShutterOpen_);
+            core_.setAutoShutter(autoShutter_);
+        } catch (Exception e) {
+            studio_.logs().logError("Couldn't restore shutter to original state");
+        }
+
+        // check if acquisition ended due to an exception and show error
+        // currentAcquisition_ can be null if an error occurred during setup
+        if (currentAcquisition_ != null) {
+            try {
+                currentAcquisition_.checkForExceptions();
+            } catch (Exception e) {
+                studio_.logs().logError(e);
+            }
         }
 
         // start polling for navigation panel

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -38,6 +38,7 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
     private boolean isPolling_; // true if polling was enabled at the start of an acquisition
 
+    PLogicDispim controller_;
     private boolean isShutterOpen_;
     private boolean autoShutter_;
 
@@ -79,7 +80,7 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
         final boolean isUsingPLC = model_.devices().isUsingPLogic();
 
-        PLogicDispim controller = null;
+        controller_ = null;
 
         // Assume demo mode if default camera is DemoCamera
         boolean demoMode = false;
@@ -93,9 +94,9 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
         if (!demoMode) {
 
             if (isUsingPLC) {
-                controller = new PLogicDispim(model_);
+                controller_ = new PLogicDispim(model_);
 
-                final boolean success = doHardwareCalculations(controller);
+                final boolean success = doHardwareCalculations(controller_);
                 if (!success) {
                     return false; // early exit => could not set up hardware
                 }
@@ -330,7 +331,7 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
 
 
-        final PLogicDispim controllerInstance = controller;
+        final PLogicDispim controllerInstance = controller_;
         // TODO This after camera hook is called after the camera has been readied to acquire a
         //  sequence. I assume we want to tell the Tiger to start sending TTLs etc here
         currentAcquisition_.addHook(new AcquisitionHook() {
@@ -477,15 +478,6 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
         studio_.logs().logMessage("diSPIM plugin acquisition " +
                 " took: " + (System.currentTimeMillis() - acqButtonStart) + "ms");
 
-        // clean up controller settings after acquisition
-        // want to do this, even with demo cameras, so we can test everything else
-        // TODO: figure out if we really want to return piezos to 0 position (maybe center position,
-        //   maybe not at all since we move when we switch to setup tab, something else??)
-        if (isUsingPLC && controller != null) {
-            controller.cleanUpControllerAfterAcquisition(acqSettings_, true);
-            controller.stopSPIMStateMachines();
-        }
-
         // TODO: execute any end-acquisition runnables
 
         return true;
@@ -505,6 +497,15 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
             }
         } catch (Exception e) {
             studio_.logs().logError("Could not stop camera sequences: " + e.getMessage());
+        }
+
+        // clean up controller settings after acquisition
+        // want to do this, even with demo cameras, so we can test everything else
+        // TODO: figure out if we really want to return piezos to 0 position (maybe center position,
+        //   maybe not at all since we move when we switch to setup tab, something else??)
+        if (model_.devices().isUsingPLogic() && controller_ != null) {
+            controller_.cleanUpControllerAfterAcquisition(acqSettings_, true);
+            controller_.stopSPIMStateMachines();
         }
 
         // Restore shutter/autoshutter to original state

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -507,6 +507,19 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
     @Override
     boolean finish() {
 
+        final CameraBase[] cameras = model_.devices().imagingCameras();
+
+        // Stop all cameras sequences
+        try {
+            for (CameraBase camera : cameras) {
+                if (core_.isSequenceRunning(camera.getDeviceName())) {
+                    core_.stopSequenceAcquisition(camera.getDeviceName());
+                }
+            }
+        } catch (Exception e) {
+            studio_.logs().logError("Could not stop camera sequences: " + e.getMessage());
+        }
+
         // start polling for navigation panel
         if (isPolling_) {
             studio_.logs().logMessage("started position polling after acquisition");

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -526,6 +526,9 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
             }
         }
 
+        // unregister to stop ghost events
+        studio_.events().unregisterForEvents(this);
+
         // start polling for navigation panel
         if (isPolling_) {
             studio_.logs().logMessage("started position polling after acquisition");

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -706,7 +706,7 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
         // want to do this, even with demo cameras, so we can test everything else
         // TODO: figure out if we really want to return piezos to 0 position (maybe center position,
         //   maybe not at all since we move when we switch to setup tab, something else??)
-        if (model_.devices().isUsingPLogic()) {
+        if (model_.devices().isUsingPLogic() && controller_ != null) {
             controller_.cleanUpControllerAfterAcquisition(acqSettings_, true);
             controller_.stopSPIMStateMachines();
         }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -52,7 +52,7 @@ import java.util.ArrayList;
 public class AcquisitionEngineScape extends AcquisitionEngine {
 
     PLogicScape controller_;
-    ArrayList<Double> savedExposures_;
+    ArrayList<Double> savedExposures_ = new ArrayList<>();
     Point2D.Double xyPosUm_;
     private double origSpeedX_;
     private double origAccelX_;
@@ -749,10 +749,12 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
         // TODO: execute any end-acquisition runnables
 
         // set the camera trigger modes back to internal for live mode
-        for (int i = 0; i < cameras.length; i++) {
-            CameraBase camera = cameras[i];
-            camera.setTriggerMode(CameraMode.INTERNAL);
-            camera.setExposure(savedExposures_.get(i));
+        if (savedExposures_.size() == cameras.length) {
+            for (int i = 0; i < cameras.length; i++) {
+                CameraBase camera = cameras[i];
+                camera.setTriggerMode(CameraMode.INTERNAL);
+                camera.setExposure(savedExposures_.get(i));
+            }
         }
 
         if (acqSettings_.isSavingImagesDuringAcquisition()) {


### PR DESCRIPTION

## Summary
Ported `finish()` lifecycle cleanup from `AcquisitionEngineScape` to `AcquisitionEngineDispim` for parity between the two acquisition engines. diSPIM's `finish()` was previously almost a no-op (just polling restart) — the equivalent cleanup already existed, but was inlined at the tail of `run()` using local variables that weren't reachable from `finish()`. Promoted that state to instance fields (`controller_`, `savedExposures_`, `isShutterOpen_`, `autoShutter_`) and moved the cleanup into `finish()` so it now runs reliably regardless of how the acquisition ends.

### New in diSPIM's `finish()`
- Stop any still-running camera sequence acquisitions
- PLogic/controller cleanup (`cleanUpControllerAfterAcquisition`, `stopSPIMStateMachines`)
- Shutter/autoshutter restore
- Check for acquisition exceptions
- Camera trigger-mode reset to `INTERNAL` + exposure restore
- `unregisterForEvents(this)` — diSPIM registered for events on every acquisition run but never unregistered (listener leak); now fixed

### Bugs found along the way (fixed in both engines)
1. **NPE risk in PLogic cleanup**: SCAPE's `finish()` called `controller_.cleanUpControllerAfterAcquisition(...)` with no null check. In demo mode, `controller_` is never instantiated even when "use PLogic" is enabled in settings — so `finish()` would NPE right there and silently skip everything after it (shutter restore, exception check, camera reset). Fixed by guarding with `controller_ != null` in both engines.
2. **NPE risk in exposure restore**: `savedExposures_` had no initial value in either engine, only getting populated near the top of `run()`. If `run()` threw before reaching that point, `finish()` would still execute (via the outer `finally`) and NPE on `save