### PR TITLE
SCAPE: only write the position list when saving images during the acuisition

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -246,7 +246,8 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
         }
 
         // write the position list if we are using multiple positions
-        if (model_.acquisitions().settings().isUsingMultiplePositions()) {
+        if (model_.acquisitions().settings().isSavingImagesDuringAcquisition()
+                && model_.acquisitions().settings().isUsingMultiplePositions()) {
             final PositionList positionList = model_.studio().positions().getPositionList();
             if (positionList.getNumberOfPositions() > 0) {
                 try {


### PR DESCRIPTION
`position_list.pos` was being written to the save directory whenever multiple positions were in use, regardless of whether "save images during acquisition" was checked. The `acq_settings.json` write right above it already respected that checkbox, this one didn't, so leaving "save images" unchecked with multiple positions configured still silently created a save directory containing just a stray `position_list.pos` file.

## Change
`AcquisitionEngineScape.java`: added `isSavingImagesDuringAcquisition()` to the condition to prevent the position-list write, matching the existing `acq_settings.json` check.

```java
// write the position list if we are using multiple positions
if (model_.acquisitions().settings().isSavingImagesDuringAcquisition()
        && model_.acquisitions().settings().isUsingMultiplePositions()) {
```