### PR TITLE
make sure that the primary camera is always active, even with > 1 camera

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/CameraTab.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/gui/tabs/CameraTab.java
@@ -122,11 +122,17 @@ public class CameraTab extends Panel implements ListeningPanel {
 
         // populate spinner with current roi
         btnCurrentROI_.registerListener(() -> {
-            final Rectangle roi = model_.devices().firstImagingCamera().getROI();
-            spnOffsetX_.setValue(roi.x);
-            spnOffsetY_.setValue(roi.y);
-            spnWidth_.setValue(roi.width);
-            spnHeight_.setValue(roi.height);
+            try {
+                final Rectangle roi = model_.devices().firstImagingCamera().getROI();
+                spnOffsetX_.setValue(roi.x);
+                spnOffsetY_.setValue(roi.y);
+                spnWidth_.setValue(roi.width);
+                spnHeight_.setValue(roi.height);
+            } catch (Exception e) {
+                model_.studio().logs().showError(
+                        "No imaging camera available; check that a camera is assigned in the hardware "
+                        + "configuration and set as Active on the Acquisition tab.");
+            }
         });
     }
 

--- a/src/main/java/org/micromanager/lightsheetmanager/model/DeviceManager.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/DeviceManager.java
@@ -396,10 +396,9 @@ public class DeviceManager {
     public void useDefaultImagingCameraOrder() {
         final List<CameraData> cameras = new ArrayList<>();
         final String[] cameraNames = imagingCameraNames();
-        for (String name : cameraNames) {
-            // Note: there is no ui control to change the active state of the
-            // camera when there is only 1 camera, so make sure it's active.
-            cameras.add(new CameraData(name, cameraNames.length == 1));
+        for (int i = 0; i < cameraNames.length; i++) {
+            // the first camera is always the default primary camera, so make sure it's active
+            cameras.add(new CameraData(cameraNames[i], i == 0));
         }
         // update settings with default camera order
         model_.acquisitions().settingsBuilder()


### PR DESCRIPTION
It looks like the old code to make sure the primary camera is active only worked for systems that have 1 camera.

On systems with more than 1 camera, the default state for all cameras would be false.

I also added a `try/catch` to deal with some NPEs when the camera is `"Undefined"`.

```java

Old code:
// Note: there is no ui control to change the active state of the
// camera when there is only 1 camera, so make sure it's active.
cameras.add(new CameraData(name, cameraNames.length == 1));

New code:
// the first camera is always the default primary camera, so make sure it's active
cameras.add(new CameraData(cameraNames[i], i == 0));
```