### PR TITLE
SCAPE: make sure all of the scanner settings are set in the PLogicScape and PLogicDispim

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/PLogicDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/PLogicDispim.java
@@ -622,6 +622,15 @@ public class PLogicDispim {
 
                 scanner.setSPIMAlternateDirections(oppositeDirections);
                 scanner.setSPIMScanDuration(settings.timing().scanDuration());
+                // program the remaining per-slice timing onto the scanner card; diSPIM 1.4 wrote
+                // these through the advanced-timing GUI spinner bindings, a path lost in the port,
+                // so galvo scans ran on whatever stale timing was left on the card (issue #417)
+                scanner.setSPIMDelayBeforeScan(settings.timing().delayBeforeScan());
+                scanner.setSPIMNumScansPerSlice(settings.timing().scansPerSlice());
+                scanner.setSPIMDelayBeforeLaser(settings.timing().delayBeforeLaser());
+                scanner.setSPIMLaserDuration(settings.timing().laserTriggerDuration());
+                scanner.setSPIMDelayBeforeCamera(settings.timing().delayBeforeCamera());
+                scanner.setSPIMCameraDuration(settings.timing().cameraTriggerDuration());
                 scanner.sa().setAmplitudeY(sliceAmplitude);
                 scanner.sa().setOffsetY(sliceCenter);
                 scanner.setSPIMNumSlices(numSlicesHW);

--- a/src/main/java/org/micromanager/lightsheetmanager/model/PLogicScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/PLogicScape.java
@@ -493,6 +493,15 @@ public class PLogicScape {
             scanner_.setSPIMAlternateDirections(oppositeDirections);
             scanner_.setSPIMScanDuration(
                   settings.timing().sliceDuration() - settings.timing().delayBeforeScan());
+            // program the remaining per-slice timing onto the scanner card; diSPIM 1.4 wrote
+            // these through the advanced-timing GUI spinner bindings, a path lost in the port,
+            // so galvo scans ran on whatever stale timing was left on the card (issue #417)
+            scanner_.setSPIMDelayBeforeScan(settings.timing().delayBeforeScan());
+            scanner_.setSPIMNumScansPerSlice(settings.timing().scansPerSlice());
+            scanner_.setSPIMDelayBeforeLaser(settings.timing().delayBeforeLaser());
+            scanner_.setSPIMLaserDuration(settings.timing().laserTriggerDuration());
+            scanner_.setSPIMDelayBeforeCamera(settings.timing().delayBeforeCamera());
+            scanner_.setSPIMCameraDuration(settings.timing().cameraTriggerDuration());
             scanner_.sa().setAmplitudeY(sliceAmplitude);
             scanner_.sa().setOffsetY(sliceCenter);
             scanner_.setSPIMNumSlices(numSlicesHW);


### PR DESCRIPTION
I think this should fix issue #417, the diSPIM plugin used a different method to set these values so they were stale in LSM.