### PR TITLE
Add greppable markers to CoreLog for all microscope geometries; elapsed time report even during errors

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -168,8 +168,7 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                     // must ALWAYS run: if currentAcquisition_ is left set, every future
                     // acquisition is rejected until the plugin restarts
                     currentAcquisition_ = null;
-                    // LSM-ACQ-START/STOP bracket the acquisition window for CoreLog diffing
-                    // STOP in the innermost finally: fires on completion, error, abort, throwing finish()
+                    // LSM-ACQ-STOP in the innermost finally: fires on completion, error, abort, throwing finish()
                     if (runId != -1) {
                         final long elapsedMs = (System.nanoTime() - startNs) / 1_000_000L;
                         studio_.logs().logMessage("LSM-ACQ-STOP " + runId + " " + elapsedMs + "ms");

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -171,7 +171,7 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                     // LSM-ACQ-STOP in the innermost finally: fires on completion, error, abort, throwing finish()
                     if (runId != -1) {
                         final long elapsedMs = (System.nanoTime() - startNs) / 1_000_000L;
-                        studio_.logs().logMessage("LSM-ACQ-STOP " + runId + " " + elapsedMs + "ms");
+                        studio_.logs().logMessage("LSM-ACQ-STOP " + runId + " " + elapsedMs + " ms");
                     }
                 }
             }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -16,7 +16,6 @@ import org.micromanager.data.SummaryMetadata;
 import org.micromanager.data.internal.DefaultSummaryMetadata;
 import org.micromanager.data.internal.PropertyKey;
 import org.micromanager.lightsheetmanager.LightSheetManager;
-import org.micromanager.lightsheetmanager.LightSheetManagerPlugin;
 import org.micromanager.lightsheetmanager.api.AcquisitionManager;
 import org.micromanager.lightsheetmanager.api.data.AcquisitionMode;
 import org.micromanager.lightsheetmanager.api.internal.ScapeAcquisitionSettings;
@@ -32,11 +31,14 @@ import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquistionControlCallbacks {
 
     protected final Studio studio_;
     protected final CMMCore core_;
+
+    private static final AtomicLong runIdCounter_ = new AtomicLong();
 
     protected ScapeAcquisitionSettings.Builder asb_;
     protected ScapeAcquisitionSettings acqSettings_;
@@ -119,6 +121,10 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                 return;
             }
 
+            // marker data
+            long runId = -1; // set at START; guards STOP so the speed-test path emits no marker
+            long startNs = 0; // set alongside runId at START
+
             try {
                 updateSettings(); // make sure settings are current
 
@@ -133,7 +139,13 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                     return; // early exit => do speed test
                 }
 
-                studio_.logs().logMessage("Preparing Acquisition: plugin version " + LightSheetManagerPlugin.version);
+                // LSM-ACQ-START/STOP bracket the acquisition window for CoreLog diffing
+                runId = runIdCounter_.incrementAndGet();
+                // nanoTime() = monotonic; a wall-clock (currentTimeMillis) jump
+                // mid-run can't corrupt the elapsed duration
+                startNs = System.nanoTime();
+                studio_.logs().logMessage("LSM-ACQ-START " + runId
+                        + " " + acqSettings_.acquisitionMode());
 
                 try {
                     if (!setup()) {
@@ -156,6 +168,12 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                     // must ALWAYS run: if currentAcquisition_ is left set, every future
                     // acquisition is rejected until the plugin restarts
                     currentAcquisition_ = null;
+                    // LSM-ACQ-START/STOP bracket the acquisition window for CoreLog diffing
+                    // STOP in the innermost finally: fires on completion, error, abort, throwing finish()
+                    if (runId != -1) {
+                        final long elapsedMs = (System.nanoTime() - startNs) / 1_000_000L;
+                        studio_.logs().logMessage("LSM-ACQ-STOP " + runId + " " + elapsedMs + "ms");
+                    }
                 }
             }
         });

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -245,8 +245,6 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 //                  AcquisitionAPI.BEFORE_HARDWARE_HOOK);
 //        }
 
-        long acqButtonStart = System.currentTimeMillis();
-
         ////////////  Acquisition hooks ////////////////////
         // These functions will be run on different threads during the acquisition process
         //    Hooks will run on the Acquisition Engine thread--the one that controls all hardware
@@ -482,12 +480,7 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
         currentAcquisition_.waitForCompletion();
 
-        // cleanup
-        studio_.logs().logMessage("diSPIM plugin acquisition " +
-                " took: " + (System.currentTimeMillis() - acqButtonStart) + "ms");
-
         // TODO: execute any end-acquisition runnables
-
         return true;
     }
 

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -320,8 +320,6 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
 //                  AcquisitionAPI.BEFORE_HARDWARE_HOOK);
 //        }
 
-        long acqButtonStart = System.currentTimeMillis();
-
         ////////////  Acquisition hooks ////////////////////
         // These functions will be run on different threads during the acquisition process
         //    Hooks will run on the Acquisition Engine thread--the one that controls all hardware
@@ -690,10 +688,6 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
         currentAcquisition_.finish();
 
         currentAcquisition_.waitForCompletion();
-
-        // report elapsed time
-        final long elapsedTimeMs = System.currentTimeMillis() - acqButtonStart;
-        studio_.logs().logMessage("SCAPE plugin acquisition took: " + elapsedTimeMs + " milliseconds");
 
         return true;
     }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/DeviceAdapter.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/DeviceAdapter.java
@@ -2,6 +2,7 @@ package org.micromanager.lightsheetmanager.model.devices;
 
 import mmcorej.DeviceType;
 import org.micromanager.Studio;
+import org.micromanager.lightsheetmanager.LightSheetManagerPlugin;
 import org.micromanager.lightsheetmanager.api.data.GeometryType;
 import org.micromanager.lightsheetmanager.api.data.LightSheetType;
 import org.micromanager.lightsheetmanager.model.utils.MathUtils;
@@ -44,6 +45,8 @@ public class DeviceAdapter extends DeviceBase {
 
         // if GeometryType.UNKNOWN then we open the plugin error screen
         geometryType_ = GeometryType.fromString(getProperty("MicroscopeGeometry"));
+        studio_.logs().logMessage("LSM-SESSION plugin-v" + LightSheetManagerPlugin.version
+                + " adapter-v" + version_ + " " + geometryType_);
         if (geometryType_ == GeometryType.UNKNOWN) {
             studio_.logs().logError("LightSheetDeviceManager: Failed to identify microscope geometry! "
                     + "Device adapter returned: " + getProperty("MicroscopeGeometry"));


### PR DESCRIPTION
This PR restores functionality to LSM from the 1.4 diSPIM plugin:
  - LSM measures the same timing window as the original plugin
  - LSM also reports the elapsed time on errors which if failed to do before

There are some known errors that relate to hangs in `run()`, the solution for those problems is more involved and will be revisited when working on other issues, so a hang in `run()` wont show `LSM-ACQ-STOP` right now.

The `LSM-ACQ-START` / `LSM-ACQ-STOP` markers bracket every acquisition, so one `sed` pulls a single run's window straight out of a CoreLog, no tooling required:

`sed -n '/LSM-ACQ-START 4 /,/LSM-ACQ-STOP 4 /p' CoreLog.txt`

If you want line numbers you can use `grep`.

---
Because `LSM-ACQ-STOP` times the whole acquisition window (not just the imaging body), per-mode overhead is obvious at a glance. From one five-run session:

```
LSM-ACQ-STOP 1 3636 ms   # Galvo scan
LSM-ACQ-STOP 2 2896 ms   # Galvo scan
LSM-ACQ-STOP 3 2890 ms   # Galvo scan
LSM-ACQ-STOP 4 8505 ms   # Stage scan  <------------- ~5.6 s longer!
LSM-ACQ-STOP 5 2847 ms   # No scan (fixed sheet)
```

The stage-scan run is ~5.6 s longer than the others, an extra delay in the stage-scan cleanup path that's easy to miss but jumps right out once each run's full window is timed. (The old per-engine "acquisition took" line measured only the imaging body, so it hid this.)

Surfaced a stage-scan cleanup delay; fix in the next PR, this was discovered as a result of the #404 CoreLog that @oleksiievetsno posted.