### PR TITLE
Fix for extra 5 s stage scan time due to reading stale stage scan state value

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/PLogicScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/PLogicScape.java
@@ -1060,7 +1060,7 @@ public class PLogicScape {
             final long deadline = System.currentTimeMillis() + timeoutStageScanCleanupMs;
             boolean done = false;
             while (!done) {
-                done = xyStage_.getScanState() == ASIXYStage.ScanState.IDLE;
+                done = xyStage_.getScanStateForceRefresh() == ASIXYStage.ScanState.IDLE;
                 if (!done && System.currentTimeMillis() > deadline) {
                     xyStage_.setScanState(ASIXYStage.ScanState.IDLE); // force-set to idle
                     studio_.logs().logError("Force-set XY stage scan to IDLE state with stage speed "

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/vendor/ASITigerBase.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/vendor/ASITigerBase.java
@@ -103,4 +103,18 @@ public abstract class ASITigerBase extends DeviceBase {
         return false;
     }
 
+    public String getPropertyForceRefresh(final String propertyName) {
+        final boolean wasOn = isRefreshPropertyValuesOn();
+        if (!wasOn) {
+            setRefreshPropertyValues(true);
+        }
+        try {
+            return getProperty(propertyName);
+        } finally {
+            if (!wasOn) {
+                setRefreshPropertyValues(false);  // always restore; do not get stuck on "Yes"
+            }
+        }
+    }
+
 }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/vendor/ASIXYStage.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/vendor/ASIXYStage.java
@@ -165,6 +165,10 @@ public class ASIXYStage extends ASITigerBase {
         return ScanState.fromString(getProperty(Properties.SCAN_STATE));
     }
 
+    public ScanState getScanStateForceRefresh() {
+        return ScanState.fromString(getPropertyForceRefresh(Properties.SCAN_STATE));
+    }
+
     public void setScanSettlingTime(final double milliseconds) {
         setPropertyFloat(Properties.SCAN_SETTLING_TIME, milliseconds);
     }


### PR DESCRIPTION
@oleksiievetsno noticed an extra delay in stage scan. #404 was closed, but the delay turned out to be real, this is the fix.

The 1.4 plugin forces a fresh read of the stage-scan state (via RefreshPropertyValues); the LSM port was reading the cached value, which never updates to IDLE, so the cleanup wait always ran the full 5 s timeout and fell through to a forced Force-set XY stage scan to IDLE.

CoreLog validation: the 5 s tax is gone (stage-scan runs dropped from ~8500 ms to ~4600 ms, and the Force-set… fallback no longer fires):
```
STOP 1  3556 ms   Galvo scan
STOP 2  5128 ms   Stage scan
STOP 3  4570 ms   Stage scan
STOP 4  2297 ms   No scan
STOP 5  4564 ms   Stage scan
The residual ~1 s over galvo is the real physical stage retrace.
```
---