### PR TITLE
fix the end-of-run save and clean up finish() across both engines

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -168,6 +168,8 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                     // must ALWAYS run: if currentAcquisition_ is left set, every future
                     // acquisition is rejected until the plugin restarts
                     currentAcquisition_ = null;
+                    // free the datastore at acq end so a large store isn't kept in memory; matches MM's AcqEngJAdapter.onAcquisitionEnded
+                    datastore_ = null;
                     // LSM-ACQ-STOP in the innermost finally: fires on completion, error, abort, throwing finish()
                     if (runId != -1) {
                         final long elapsedMs = (System.nanoTime() - startNs) / 1_000_000L;

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -46,6 +46,8 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
     private final ExecutorService acquisitionExecutor_ = Executors.newSingleThreadExecutor(
             r -> new Thread(r, "Acquisition Thread"));
     protected volatile Acquisition currentAcquisition_ = null; // TODO: consider making a getter rather than protected?
+    // true once setup() succeeds and run() is about to begin; the end-of-run save only runs when this is true
+    protected boolean acquisitionStarted_ = false;
 
     private final AutofocusAdapter autofocus_;
 
@@ -156,6 +158,8 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                     studio_.logs().showError(e, "Error during acquisition setup");
                     return; // early exit => stop acquisition
                 }
+                // setup succeeded and we are about to run; end-of-run work (the save) is now valid
+                acquisitionStarted_ = true;
                 run(); // run the acquisition and block until complete
             } catch (Exception e) {
                 studio_.logs().showError(e);
@@ -170,6 +174,8 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
                     currentAcquisition_ = null;
                     // free the datastore at acq end so a large store isn't kept in memory; matches MM's AcqEngJAdapter.onAcquisitionEnded
                     datastore_ = null;
+                    // reset for the next run; must be here (always runs), not in finish() which can throw
+                    acquisitionStarted_ = false;
                     // LSM-ACQ-STOP in the innermost finally: fires on completion, error, abort, throwing finish()
                     if (runId != -1) {
                         final long elapsedMs = (System.nanoTime() - startNs) / 1_000_000L;

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -50,7 +50,7 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
     private final AutofocusAdapter autofocus_;
 
     private DataStorage data_; // TODO: use this, has enum that needs moved/deleted?
-    protected Datastore curStore_;
+    protected Datastore datastore_;
     protected Pipeline curPipeline_;
     protected long nextWakeTime_ = -1;
 
@@ -375,7 +375,7 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
 
     @Override
     public DataProvider getAcquisitionDatastore() {
-        return curStore_;
+        return datastore_;
     }
 
 }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -21,6 +21,7 @@ import org.micromanager.lightsheetmanager.api.data.ChannelMode;
 import org.micromanager.lightsheetmanager.api.internal.DispimAcquisitionSettings;
 import org.micromanager.lightsheetmanager.api.internal.DefaultTimingSettings;
 import org.micromanager.lightsheetmanager.model.DataStorage;
+import org.micromanager.lightsheetmanager.model.utils.FileUtils;
 import org.micromanager.lightsheetmanager.LightSheetManager;
 import org.micromanager.lightsheetmanager.model.PLogicDispim;
 import org.micromanager.lightsheetmanager.model.devices.NIDAQ;
@@ -521,6 +522,8 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
             controller_.stopSPIMStateMachines();
         }
 
+        // TODO: stage scan work pending (SCAPE finish() restores stage speed/position here)
+
         // Restore shutter/autoshutter to original state
         try {
             core_.setShutterOpen(isShutterOpen_);
@@ -556,6 +559,21 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
                 currentAcquisition_.checkForExceptions();
             } catch (Exception e) {
                 studio_.logs().logError(e);
+            }
+        }
+
+        // TODO: execute any end-acquisition runnables
+
+        if (acqSettings_.isSavingImagesDuringAcquisition()) {
+            final String savePath = FileUtils.createUniquePath(
+                    acqSettings_.saveDirectory(), acqSettings_.saveNamePrefix());
+            try {
+                // convert from DataStorage.SaveMode to Datastore.SaveMode
+                final Datastore.SaveMode saveMode =
+                        DataStorage.SaveMode.convert(acqSettings_.saveMode());
+                curStore_.save(saveMode, savePath);
+            } catch (Exception e) {
+                model_.studio().logs().showError("could not save the acquisition data to: \n" + savePath);
             }
         }
     }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -564,7 +564,9 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
         // TODO: execute any end-acquisition runnables
 
-        if (acqSettings_.isSavingImagesDuringAcquisition()) {
+        // don't save if the run never started or produced no images
+        if (acquisitionStarted_ && acqSettings_.isSavingImagesDuringAcquisition()
+                && datastore_.getNumImages() > 0) {
             final String savePath = FileUtils.createUniquePath(
                     acqSettings_.saveDirectory(), acqSettings_.saveNamePrefix());
             try {

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -486,8 +486,20 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
     @Override
     void finish() {
+        // finish() runs on EVERY path (the requestRun finally), even a setup-abort where the
+        // acquisition never started. That splits its work into two jobs. Keep them grouped:
+        //
+        //   Job A: restore hardware/system state. Must ALWAYS run: setup() can mutate hardware
+        //          before it fails, so each step self-guards on whether its state was changed.
+        //   Job B: end-of-acquisition work. Only valid if the run actually happened, so each step
+        //          self-guards on that (don't, e.g., save a datastore that was never filled).
+        //
+        // Adding a step? Pick its job: Job A runs unconditionally, Job B only when the run happened.
+        // Don't interleave them.
 
         final CameraBase[] cameras = model_.devices().imagingCameras();
+
+        // --- Job A ---
 
         // Stop all cameras sequences
         try {
@@ -517,16 +529,6 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
             studio_.logs().logError("Couldn't restore shutter to original state");
         }
 
-        // check if acquisition ended due to an exception and show error
-        // currentAcquisition_ can be null if an error occurred during setup
-        if (currentAcquisition_ != null) {
-            try {
-                currentAcquisition_.checkForExceptions();
-            } catch (Exception e) {
-                studio_.logs().logError(e);
-            }
-        }
-
         // set the camera trigger modes back to internal for live mode
         if (savedExposures_.size() == cameras.length) {
             for (int i = 0; i < cameras.length; i++) {
@@ -543,6 +545,18 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
         if (isPolling_) {
             studio_.logs().logMessage("started position polling after acquisition");
             model_.positions().startPolling();
+        }
+
+        // --- Job B ---
+
+        // check if acquisition ended due to an exception and show error
+        // currentAcquisition_ can be null if an error occurred during setup
+        if (currentAcquisition_ != null) {
+            try {
+                currentAcquisition_.checkForExceptions();
+            } catch (Exception e) {
+                studio_.logs().logError(e);
+            }
         }
     }
 

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -225,14 +225,14 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
         MMAcquisition acq = new MMAcquisition(studio_, dsmd,
                 this, sequenceSettingsBuilder.build());
 
-        curStore_ = acq.getDatastore();
+        datastore_ = acq.getDatastore();
         curPipeline_ = acq.getPipeline();
-        sink.setDatastore(curStore_);
+        sink.setDatastore(datastore_);
         sink.setPipeline(curPipeline_);
 
         studio_.events().registerForEvents(this);
         // commented because this is prob specific to MM MDAs
-//        studio_.events().post(new DefaultAcquisitionStartedEvent(curStore_, this,
+//        studio_.events().post(new DefaultAcquisitionStartedEvent(datastore_, this,
 //              acquisitionSettings));
 
 
@@ -571,7 +571,7 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
                 // convert from DataStorage.SaveMode to Datastore.SaveMode
                 final Datastore.SaveMode saveMode =
                         DataStorage.SaveMode.convert(acqSettings_.saveMode());
-                curStore_.save(saveMode, savePath);
+                datastore_.save(saveMode, savePath);
             } catch (Exception e) {
                 model_.studio().logs().showError("could not save the acquisition data to: \n" + savePath);
             }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -775,7 +775,7 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
                 final Datastore.SaveMode saveMode =
                         DataStorage.SaveMode.convert(acqSettings_.saveMode());
                 curStore_.save(saveMode, savePath);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 model_.studio().logs().showError("could not save the acquisition data to: \n" + savePath);
             }
         }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -789,7 +789,9 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
 
         // TODO: execute any end-acquisition runnables
 
-        if (acqSettings_.isSavingImagesDuringAcquisition()) {
+        // don't save if the run never started or produced no images
+        if (acquisitionStarted_ && acqSettings_.isSavingImagesDuringAcquisition()
+                && datastore_.getNumImages() > 0) {
             final String savePath = FileUtils.createUniquePath(
                     acqSettings_.saveDirectory(), acqSettings_.saveNamePrefix());
             try {

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -43,7 +43,6 @@ import org.micromanager.lightsheetmanager.model.utils.NumberUtils;
 import javax.swing.JLabel;
 import java.awt.geom.Point2D;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -299,14 +298,14 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
         MMAcquisition acq = new MMAcquisition(studio_, dsmd,
                 this, sequenceSettingsBuilder.build());
 
-        curStore_ = acq.getDatastore();
+        datastore_ = acq.getDatastore();
         curPipeline_ = acq.getPipeline();
-        sink.setDatastore(curStore_);
+        sink.setDatastore(datastore_);
         sink.setPipeline(curPipeline_);
 
         studio_.events().registerForEvents(this);
         // commented because this is prob specific to MM MDAs
-//        studio_.events().post(new DefaultAcquisitionStartedEvent(curStore_, this,
+//        studio_.events().post(new DefaultAcquisitionStartedEvent(datastore_, this,
 //              acquisitionSettings));
 
 
@@ -797,7 +796,7 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
                 // convert from DataStorage.SaveMode to Datastore.SaveMode
                 final Datastore.SaveMode saveMode =
                         DataStorage.SaveMode.convert(acqSettings_.saveMode());
-                curStore_.save(saveMode, savePath);
+                datastore_.save(saveMode, savePath);
             } catch (Exception e) {
                 model_.studio().logs().showError("could not save the acquisition data to: \n" + savePath);
             }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -694,8 +694,20 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
 
     @Override
     void finish() {
+        // finish() runs on EVERY path (the requestRun finally), even a setup-abort where the
+        // acquisition never started. That splits its work into two jobs. Keep them grouped:
+        //
+        //   Job A: restore hardware/system state. Must ALWAYS run: setup() can mutate hardware
+        //          before it fails, so each step self-guards on whether its state was changed.
+        //   Job B: end-of-acquisition work. Only valid if the run actually happened, so each step
+        //          self-guards on that (don't, e.g., save a datastore that was never filled).
+        //
+        // Adding a step? Pick its job: Job A runs unconditionally, Job B only when the run happened.
+        // Don't interleave them.
 
         final CameraBase[] cameras = model_.devices().imagingCameras();
+
+        // --- Job A ---
 
         // Stop all cameras sequences
         try {
@@ -746,6 +758,26 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
             studio_.logs().logError("Couldn't restore shutter to original state");
         }
 
+        // set the camera trigger modes back to internal for live mode
+        if (savedExposures_.size() == cameras.length) {
+            for (int i = 0; i < cameras.length; i++) {
+                CameraBase camera = cameras[i];
+                camera.setTriggerMode(CameraMode.INTERNAL);
+                camera.setExposure(savedExposures_.get(i));
+            }
+        }
+
+        // unregister to stop ghost events
+        studio_.events().unregisterForEvents(this);
+
+        // start polling for navigation panel
+        if (isPolling_) {
+            studio_.logs().logMessage("started position polling after acquisition");
+            model_.positions().startPolling();
+        }
+
+        // --- Job B ---
+
         // check if acquisition ended due to an exception and show error
         // currentAcquisition_ can be null if an error occurred during setup
         if (currentAcquisition_ != null) {
@@ -758,15 +790,6 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
 
         // TODO: execute any end-acquisition runnables
 
-        // set the camera trigger modes back to internal for live mode
-        if (savedExposures_.size() == cameras.length) {
-            for (int i = 0; i < cameras.length; i++) {
-                CameraBase camera = cameras[i];
-                camera.setTriggerMode(CameraMode.INTERNAL);
-                camera.setExposure(savedExposures_.get(i));
-            }
-        }
-
         if (acqSettings_.isSavingImagesDuringAcquisition()) {
             final String savePath = FileUtils.createUniquePath(
                     acqSettings_.saveDirectory(), acqSettings_.saveNamePrefix());
@@ -778,15 +801,6 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
             } catch (Exception e) {
                 model_.studio().logs().showError("could not save the acquisition data to: \n" + savePath);
             }
-        }
-
-        // unregister to stop ghost events
-        studio_.events().unregisterForEvents(this);
-
-        // start polling for navigation panel
-        if (isPolling_) {
-            studio_.logs().logMessage("started position polling after acquisition");
-            model_.positions().startPolling();
         }
     }
 

--- a/src/main/java/org/micromanager/lightsheetmanager/model/utils/FileUtils.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/utils/FileUtils.java
@@ -45,32 +45,6 @@ public final class FileUtils {
         }
     }
 
-    /**
-     * Returns a unique file path. Do not include the "." in the file extension.
-     *
-     * @param directory the file directory
-     * @param name the file name
-     * @param extension the file extension
-     * @return a unique file path
-     */
-    public static String createUniquePath(final String directory, final String name, final String extension) {
-        // check if the file path is available => early exit if true
-        if (!(new File(directory + File.separator + name + "." + extension).exists())) {
-            return directory + File.separator + name + "." + extension;
-        }
-        // otherwise look for an unused file path
-        String path = "";
-        int count = 0;
-        boolean found = false;
-        while (!found && count < 1_000_000) {
-            path = directory + File.separator + name + "_" + count + "." + extension;
-            found = !(new File(directory).exists());
-            count++;
-        }
-        return path;
-    }
-
-    // directory version
     public static String createUniquePath(final String directory, final String name) {
         // check if the file path is available => early exit if true
         if (!(new File(directory + File.separator + name).exists())) {


### PR DESCRIPTION
finish() saved whenever saving was requested, even when the run aborted during
setup or produced no images. On an abort the datastore has no summary metadata,
so save() threw an NPE (surfacing as "Error during acquisition cleanup"), and
every failed acquisition left an empty save folder behind.

Add acquisitionStarted_ to the base AcquisitionEngine: set true only after setup()
succeeds (right before run()) and reset in the innermost finally, so both engines
share one flag with no drift. Gate the save in both finish() methods on
acquisitionStarted_ && datastore_.getNumImages() > 0. getNumImages() is reliable
here because run() calls waitForCompletion() before returning, so all images are
drained before finish() checks the count.