### PR TITLE
Camera layer fixes + stage scan speed restore

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/DeviceManager.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/DeviceManager.java
@@ -21,6 +21,7 @@ import org.micromanager.lightsheetmanager.model.devices.cameras.DemoCamera;
 import org.micromanager.lightsheetmanager.model.devices.cameras.HamamatsuCamera;
 import org.micromanager.lightsheetmanager.model.devices.cameras.PcoCamera;
 import org.micromanager.lightsheetmanager.model.devices.cameras.PvCamera;
+import org.micromanager.lightsheetmanager.model.devices.cameras.UnknownCamera;
 import org.micromanager.lightsheetmanager.model.devices.vendor.ASIPLogic;
 import org.micromanager.lightsheetmanager.model.devices.vendor.ASIPiezo;
 import org.micromanager.lightsheetmanager.model.devices.vendor.ASIScanner;
@@ -222,10 +223,10 @@ public class DeviceManager {
                 addDevice(propertyName, deviceName, demoCamera);
                 break;
             default:
-                CameraBase camera = new CameraBase(studio_, deviceName);
+                UnknownCamera camera = new UnknownCamera(studio_, deviceName);
                 addDevice(propertyName, deviceName, camera);
-                studio_.logs().logError(
-                        "Camera device library \"" + cameraLibrary + "\" not supported, using basic camera.");
+                studio_.logs().logError("Camera device library \"" + cameraLibrary
+                        + "\" not supported; exposure and ROI will work but timing values are unknown.");
                 break;
         }
     }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -15,6 +15,7 @@ import org.micromanager.data.internal.DefaultDatastore;
 import org.micromanager.data.internal.DefaultSummaryMetadata;
 import org.micromanager.data.internal.ndtiff.NDTiffAdapter;
 import org.micromanager.internal.MMStudio;
+import org.micromanager.lightsheetmanager.api.data.CameraLibrary;
 import org.micromanager.lightsheetmanager.api.data.CameraMode;
 import org.micromanager.lightsheetmanager.api.data.GeometryType;
 import org.micromanager.lightsheetmanager.api.data.ChannelMode;
@@ -849,9 +850,20 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
                 break;
             case PSEUDO_OVERLAP:// PCO or Photometrics, enforce 0.25ms between end exposure and start of next exposure by triggering camera 0.25ms into the slice
                 cameraDuration = 1;  // doesn't really matter, 1ms should be plenty fast yet easy to see for debugging
-                // TODO: not dealing with PVCAM (maybe throw error on unknown cam lib)
-                sliceDuration = getSliceDuration(delayBeforeScan, scanDuration, scansPerSlice, delayBeforeLaser, laserDuration, delayBeforeCamera, cameraDuration);
-                cameraExposure = sliceDuration - delayBeforeCamera;  // s.cameraDelay should be 0.25ms for PCO
+                switch (CameraLibrary.fromString(camera.getDeviceLibrary())) {
+                    case PVCAM:
+                        // leave cameraExposure alone
+                        break;
+                    case PCOCAMERA:
+                        sliceDuration = getSliceDuration(delayBeforeScan, scanDuration, scansPerSlice,
+                                delayBeforeLaser, laserDuration, delayBeforeCamera, cameraDuration);
+                        cameraExposure = sliceDuration - delayBeforeCamera;  // delayBeforeCamera should be 0.25ms for PCO
+                        break;
+                    default:
+                        studio_.logs().showError("Unknown camera library for pseudo-overlap "
+                                + "calculations: " + camera.getDeviceLibrary());
+                        break;
+                }
                 if (cameraReadoutMax < 0.24) {
                     studio_.logs().showError("Camera delay should be at least 0.25ms for pseudo-overlap mode.");
                 }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -641,7 +641,8 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
         // TODO: code that doubles nrSlicesSoftware if (twoSided && acqBothCameras) missing
 
         CameraBase camera = model_.devices().device("Imaging1Camera");
-        CameraMode camMode = camera.getTriggerMode();
+        // settings are the source of truth for camera mode
+        CameraMode camMode = acqSettings_.cameraMode();
         final double cameraReadoutTime = camera.getReadoutTime(camMode);
         final double exposureTime = acqSettings_.timing().cameraExposure();
 
@@ -767,9 +768,8 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
         // TODO: do this in ui?
         camera.setTriggerMode(acqSettings_.cameraMode());
 
-        //System.out.println(camera.getDeviceName());
-        CameraMode camMode = camera.getTriggerMode();
-        //System.out.println(camMode);
+        // settings are the source of truth for camera mode
+        CameraMode camMode = acqSettings_.cameraMode();
 
         DefaultTimingSettings.Builder tsb = DefaultTimingSettings.builder();
 

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -1247,10 +1247,8 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
             cam.setTriggerMode(acqSettings_.cameraMode());
         }
 
-        // TODO: camera.getTriggerMode(); does not match up with actual selected trigger mode for PVCAM (pseudo overlap reads as edge trigger)
-        //System.out.println(camera.getDeviceName());
-        CameraMode camMode = acqSettings_.cameraMode(); // camera.getTriggerMode();
-        //System.out.println(camMode);
+        // settings are the source of truth for camera mode
+        CameraMode camMode = acqSettings_.cameraMode();
 
         final double scanLaserBufferTime = NumberUtils.roundToQuarterMs(0.25);  // below assumed to be multiple of 0.25ms
 

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -179,6 +179,9 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
                                     "stage scanning previously. Do you want to set it to 1 mm/s now?");
                     if (result) {
                         xyStage.setSpeedX(1.0);
+                        // origSpeedX_ is the value finish() restores, so it has to track the change we
+                        // just made; otherwise we put the small speed straight back at the end of the run
+                        origSpeedX_ = 1.0;
                     }
                 }
                 // TODO: add more checks from original plugin here... Z speed?

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -1352,9 +1352,17 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
                 break;
             case PSEUDO_OVERLAP:// PCO or Photometrics, enforce 0.25ms between end exposure and start of next exposure by triggering camera 0.25ms into the slice
                 // cameraTriggerDuration: doesn't really matter, 1ms should be plenty fast yet easy to see for debugging
-                // leave cameraExposure alone if using PVCAM device library
-                if (!camera.getDeviceLibrary().equals("PVCAM")) {
-                    cameraExposure = tsb.sliceDuration() - delayBeforeCamera;  // delayBeforeCamera should be 0.25ms for PCO
+                switch (CameraLibrary.fromString(camera.getDeviceLibrary())) {
+                    case PVCAM:
+                        // leave cameraExposure alone
+                        break;
+                    case PCOCAMERA:
+                        cameraExposure = tsb.sliceDuration() - delayBeforeCamera;  // delayBeforeCamera should be 0.25ms for PCO
+                        break;
+                    default:
+                        studio_.logs().showError("Unknown camera library for pseudo-overlap "
+                                + "calculations: " + camera.getDeviceLibrary());
+                        break;
                 }
                 if (cameraReadoutMax < 0.24) {
                     studio_.logs().showError("Camera delay should be at least 0.25ms for pseudo-overlap mode.");

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/AndorCamera.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/AndorCamera.java
@@ -1,7 +1,6 @@
 package org.micromanager.lightsheetmanager.model.devices.cameras;
 
 import org.micromanager.Studio;
-import org.micromanager.lightsheetmanager.api.LightSheetCamera;
 import org.micromanager.lightsheetmanager.api.data.CameraMode;
 
 import java.awt.Rectangle;
@@ -11,7 +10,7 @@ import java.awt.Rectangle;
  * <p>Device Adapter: AndorSDK3
  * <p>Camera Support: Andor Zyla 4.2, Andor Zyla 5.5
  */
-public class AndorCamera extends CameraBase implements LightSheetCamera {
+public class AndorCamera extends CameraBase {
 
     public static class Models {
         public static final String ZYLA55 = "Zyla 5.5";

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/CameraBase.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/CameraBase.java
@@ -7,12 +7,14 @@ import org.micromanager.lightsheetmanager.model.devices.DeviceBase;
 
 import java.awt.Rectangle;
 
-// TODO: consider removing implements LightSheetCamera so no default methods for subclasses
-
 /**
  * This is the base camera class.
+ *
+ * <p>Methods that need per-vendor knowledge are abstract on purpose: a camera class that
+ * forgets one fails to compile. Cameras whose device library resolves to
+ * {@code CameraLibrary.UNKNOWN} use {@link UnknownCamera}.
  */
-public class CameraBase extends DeviceBase implements LightSheetCamera {
+public abstract class CameraBase extends DeviceBase implements LightSheetCamera {
 
     protected CameraMode mode_;
 
@@ -96,32 +98,20 @@ public class CameraBase extends DeviceBase implements LightSheetCamera {
     }
 
     @Override
-    public void setBinning() {
-
-    }
+    public abstract void setBinning();
 
     @Override
-    public int getBinning() {
-        return 0;
-    }
+    public abstract int getBinning();
 
     @Override
-    public Rectangle getResolution() {
-        return new Rectangle();
-    }
+    public abstract Rectangle getResolution();
 
     @Override
-    public double getRowReadoutTime() {
-        return 0;
-    }
+    public abstract double getRowReadoutTime();
 
     @Override
-    public double getReadoutTime(CameraMode cameraMode) {
-        return 0;
-    }
+    public abstract double getReadoutTime(CameraMode cameraMode);
 
     @Override
-    public double getResetTime(CameraMode cameraMode) {
-        return 0;
-    }
+    public abstract double getResetTime(CameraMode cameraMode);
 }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/DemoCamera.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/DemoCamera.java
@@ -1,7 +1,6 @@
 package org.micromanager.lightsheetmanager.model.devices.cameras;
 
 import org.micromanager.Studio;
-import org.micromanager.lightsheetmanager.api.LightSheetCamera;
 import org.micromanager.lightsheetmanager.api.data.CameraMode;
 
 import java.awt.Rectangle;
@@ -12,7 +11,7 @@ import java.awt.Rectangle;
  * <p>Device Adapter: DHub
  * <p>Camera Support: DemoCamera
  */
-public class DemoCamera extends CameraBase implements LightSheetCamera {
+public class DemoCamera extends CameraBase {
 
     public static class Properties {
         public static final String BINNING = "Binning";

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/HamamatsuCamera.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/HamamatsuCamera.java
@@ -1,7 +1,6 @@
 package org.micromanager.lightsheetmanager.model.devices.cameras;
 
 import org.micromanager.Studio;
-import org.micromanager.lightsheetmanager.api.LightSheetCamera;
 import org.micromanager.lightsheetmanager.api.data.CameraMode;
 
 import java.awt.Rectangle;
@@ -11,7 +10,7 @@ import java.awt.Rectangle;
  * <p>Device Adapter: HamamatsuHam
  * <p>Camera Support: ORCA-Flash4, ORCA-Fusion, ORCA-Fusion BT
  */
-public class HamamatsuCamera extends CameraBase implements LightSheetCamera {
+public class HamamatsuCamera extends CameraBase {
     public static class Models {
         public static final String FUSION_BT = "C15440";
         public static final String FUSION = "C14440";

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/PcoCamera.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/PcoCamera.java
@@ -1,7 +1,6 @@
 package org.micromanager.lightsheetmanager.model.devices.cameras;
 
 import org.micromanager.Studio;
-import org.micromanager.lightsheetmanager.api.LightSheetCamera;
 import org.micromanager.lightsheetmanager.api.data.CameraMode;
 
 import java.awt.Rectangle;
@@ -12,7 +11,7 @@ import java.awt.Rectangle;
  * <p>Device Adapter: PCO_Camera
  * <p>Camera Support: Edge 5.5, Panda
  */
-public class PcoCamera extends CameraBase implements LightSheetCamera {
+public class PcoCamera extends CameraBase {
 
     public static class Models {
         public static final String EDGE55 =" 5.5";

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/PvCamera.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/PvCamera.java
@@ -1,7 +1,6 @@
 package org.micromanager.lightsheetmanager.model.devices.cameras;
 
 import org.micromanager.Studio;
-import org.micromanager.lightsheetmanager.api.LightSheetCamera;
 import org.micromanager.lightsheetmanager.api.data.CameraMode;
 
 import java.awt.Rectangle;
@@ -11,7 +10,7 @@ import java.awt.Rectangle;
  * <p>Device Adapter: PVCAM
  * <p>Camera Support: Kinetix, Prime 95B, Prime
  */
-public class PvCamera extends CameraBase implements LightSheetCamera {
+public class PvCamera extends CameraBase {
 
     public static class Models {
         public static final String PRIME = "CIS2020F";

--- a/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/UnknownCamera.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/devices/cameras/UnknownCamera.java
@@ -1,0 +1,58 @@
+package org.micromanager.lightsheetmanager.model.devices.cameras;
+
+import org.micromanager.Studio;
+import org.micromanager.lightsheetmanager.api.data.CameraMode;
+
+import java.awt.Rectangle;
+
+/**
+ * Stand-in for a camera whose device adapter the plugin does not have a class for.
+ *
+ * <p>Device setup still completes so the plugin opens and the rest of the configuration stays
+ * usable, and the generic operations inherited from {@link CameraBase} (exposure, ROI) work
+ * through the Core for any camera. Only the values that need vendor knowledge fail, and they
+ * fail loudly: returning a zero for readout or reset time would flow straight into the
+ * slice-timing math and produce a plausible-looking but wrong acquisition.
+ */
+public class UnknownCamera extends CameraBase {
+
+    public UnknownCamera(final Studio studio, final String deviceName) {
+        super(studio, deviceName);
+    }
+
+    private UnsupportedOperationException unsupported(final String what) {
+        return new UnsupportedOperationException("Camera \"" + deviceName_
+                + "\" uses a device adapter the plugin does not support, so " + what
+                + " is unknown. Supported: AndorSDK3, HamamatsuHam, PCO_Camera, PVCAM, DemoCamera.");
+    }
+
+    @Override
+    public void setBinning() {
+        throw unsupported("binning");
+    }
+
+    @Override
+    public int getBinning() {
+        throw unsupported("binning");
+    }
+
+    @Override
+    public Rectangle getResolution() {
+        throw unsupported("sensor resolution");
+    }
+
+    @Override
+    public double getRowReadoutTime() {
+        throw unsupported("row readout time");
+    }
+
+    @Override
+    public double getReadoutTime(final CameraMode cameraMode) {
+        throw unsupported("readout time");
+    }
+
+    @Override
+    public double getResetTime(final CameraMode cameraMode) {
+        throw unsupported("reset time");
+    }
+}


### PR DESCRIPTION
Stage scan

- fix stage scan speed restore, he "Max speed of X axis is small" prompt set the stage speed but not the value finish() restores, so the scan speed was written back at the end of every run and the prompt returned forever. 1.4 updates both,


Camera layer

- restore camera library switch for pseudo-overlap, 1.4 branches per camera library here with a default: error for unrecognised ones. Both engines had lost it (SCAPE collapsed it to if (!PVCAM), diSPIM dropped it entirely), so any non-PVCAM camera silently got the PCO exposure formula.
- read camera mode from settings, not camera readback, the engines asked the camera which trigger mode it was in, but that readback is lossy on PVCAM (pseudo-overlap reads back as edge trigger). 1.4 has no camera-mode getter at all, the settings are the only source. SCAPE already worked around this; diSPIM did not.
- remove redundant implements LightSheetCamera, subclasses re-declared what CameraBase already implements.
- make vendor camera methods abstract / add UnknownCamera, getResolution, getBinning, getReadoutTime, getResetTime, getRowReadoutTime and setBinning returned 0 or 0×0 on the base, so a camera class that omitted one inherited a plausible zero that fed straight into slice timing. They are now abstract. All five existing camera classes already implemented all six, so none needed changing.