### PR TITLE
restore shutter state only when a run captured it; both engines

### DIFF
--- a/src/main/java/org/micromanager/lightsheetmanager/model/UserSettings.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/UserSettings.java
@@ -95,10 +95,11 @@ public class UserSettings {
         } else {
             // validate user settings and create AcquisitionSettings object
             final Optional<JSONObject> settingsJson = validateUserSettings(json);
-            settingsJson.ifPresent(jsonObject ->
-                    loadFromJson(jsonObject.toString(), false));
-            model_.studio().logs().logDebugMessage("loaded JSON from " + key + ": "
-                    + model_.acquisitions().settings().toPrettyJson());
+            settingsJson.ifPresent(jsonObject -> {
+                loadFromJson(jsonObject.toString(), false);
+                model_.studio().logs().logDebugMessage("loaded JSON from " + key + ": "
+                        + model_.acquisitions().settings().toPrettyJson());
+            });
         }
 
         // load plugin settings or default plugin settings

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngine.java
@@ -53,6 +53,9 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
     protected Pipeline curPipeline_;
     protected long nextWakeTime_ = -1;
 
+    // null until a run captures it, cleared by finish()
+    protected ShutterState shutterState_;
+
     protected DurationPanel pnlDuration_;
 
     protected final LightSheetManager model_;
@@ -437,6 +440,23 @@ public abstract class AcquisitionEngine implements AcquisitionManager, MMAcquist
     @Override
     public DataProvider getAcquisitionDatastore() {
         return datastore_;
+    }
+
+    /**
+     * Shutter state as it was before a run changed it.
+     *
+     * <p>finish() runs on paths that never reach the capture (setup failure, speed test), so the
+     * reference is null until a run has captured it and is cleared again once restored. Assigning
+     * it is the same statement as capturing it, so the two cannot disagree.
+     */
+    protected static final class ShutterState {
+        final boolean isOpen;
+        final boolean autoShutter;
+
+        ShutterState(final boolean isOpen, final boolean autoShutter) {
+            this.isOpen = isOpen;
+            this.autoShutter = autoShutter;
+        }
     }
 
 }

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineDispim.java
@@ -42,8 +42,6 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
     PLogicDispim controller_;
     ArrayList<Double> savedExposures_ = new ArrayList<>();
-    private boolean isShutterOpen_;
-    private boolean autoShutter_;
 
 //    private DefaultAcquisitionSettingsDISPIM.Builder asb_;
    // TODO: remove this when a more generic method is available and get from base class
@@ -372,17 +370,16 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
         ///////////// Turn off autoshutter /////////////////
         try {
-            isShutterOpen_ = core_.getShutterOpen();
+            shutterState_ = new ShutterState(core_.getShutterOpen(), core_.getAutoShutter());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
 
         // TODO: should the shutter be left open for the full duration of acquisition?
         //  because that's what this code currently does
-        autoShutter_ = core_.getAutoShutter();
-        if (autoShutter_) {
+        if (shutterState_.autoShutter) {
             core_.setAutoShutter(false);
-            if (!isShutterOpen_) {
+            if (!shutterState_.isOpen) {
                 try {
                     core_.setShutterOpen(true);
                 } catch (Exception e) {
@@ -531,12 +528,16 @@ public class AcquisitionEngineDispim extends AcquisitionEngine {
 
         // TODO: stage scan work pending (SCAPE finish() restores stage speed/position here)
 
-        // Restore shutter/autoshutter to original state
-        try {
-            core_.setShutterOpen(isShutterOpen_);
-            core_.setAutoShutter(autoShutter_);
-        } catch (Exception e) {
-            studio_.logs().logError("Couldn't restore shutter to original state");
+        // Restore shutter/autoshutter to original state; null means this run never captured it
+        if (shutterState_ != null) {
+            try {
+                core_.setShutterOpen(shutterState_.isOpen);
+                core_.setAutoShutter(shutterState_.autoShutter);
+            } catch (Exception e) {
+                studio_.logs().logError("Couldn't restore shutter to original state");
+            } finally {
+                shutterState_ = null;
+            }
         }
 
         // set the camera trigger modes back to internal for live mode

--- a/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
+++ b/src/main/java/org/micromanager/lightsheetmanager/model/acquisitions/AcquisitionEngineScape.java
@@ -58,8 +58,6 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
     private double origAccelX_;
     private double scanSpeedX_;
     private double scanAccelX_;
-    private boolean isShutterOpen_;
-    private boolean autoShutter_;
     private boolean isPolling_; // true if polling was enabled at the start of an acquisition
 
     public AcquisitionEngineScape(final LightSheetManager model) {
@@ -519,17 +517,16 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
 
         ///////////// Turn off autoshutter /////////////////
         try {
-            isShutterOpen_ = core_.getShutterOpen();
+            shutterState_ = new ShutterState(core_.getShutterOpen(), core_.getAutoShutter());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
 
         // TODO: should the shutter be left open for the full duration of acquisition?
         //  because that's what this code currently does
-        autoShutter_ = core_.getAutoShutter();
-        if (autoShutter_) {
+        if (shutterState_.autoShutter) {
             core_.setAutoShutter(false);
-            if (!isShutterOpen_) {
+            if (!shutterState_.isOpen) {
                 try {
                     core_.setShutterOpen(true);
                 } catch (Exception e) {
@@ -777,12 +774,16 @@ public class AcquisitionEngineScape extends AcquisitionEngine {
             }
         }
 
-        // Restore shutter/autoshutter to original state
-        try {
-            core_.setShutterOpen(isShutterOpen_);
-            core_.setAutoShutter(autoShutter_);
-        } catch (Exception e) {
-            studio_.logs().logError("Couldn't restore shutter to original state");
+        // Restore shutter/autoshutter to original state; null means this run never captured it
+        if (shutterState_ != null) {
+            try {
+                core_.setShutterOpen(shutterState_.isOpen);
+                core_.setAutoShutter(shutterState_.autoShutter);
+            } catch (Exception e) {
+                studio_.logs().logError("Couldn't restore shutter to original state");
+            } finally {
+                shutterState_ = null;
+            }
         }
 
         // set the camera trigger modes back to internal for live mode


### PR DESCRIPTION
only log settings load when settings were loaded